### PR TITLE
Implement multiplayer start logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
 </head>
 <body>
 <canvas id="gameCanvas" width="1000" height="700"></canvas>
+<button id="startBtn" disabled>Start</button>
 </body>
 <script>
     "user strict";
@@ -52,7 +53,10 @@
     let gameOver = false, animationFrameId;
 
     /* ───────────────────────────── Setup & Join ───────────────────────────── */
-    initializeGame();
+    socket.emit('join',{ id:myId, color:myColor });
+    const startBtn = document.getElementById('startBtn');
+    startBtn.addEventListener('click', () => socket.emit('start'));
+
     function initializeGame(){
         // zufällige Start­position
         players[myId].x = config.size + Math.random()*(canvas.width  - config.size*2);
@@ -63,8 +67,6 @@
         framesUntilStateChange = randInt(minDrawFrames, maxDrawFrames);
         gameOver  = false;
         ctx.clearRect(0,0,canvas.width,canvas.height);
-
-        socket.emit('join',{ id:myId, color:myColor });
         gameLoop();
     }
 
@@ -83,6 +85,15 @@
     socket.on('dead', ({ id })=>{
         if(players[id]) players[id].alive=false;
         if(id===myId)   endGame();
+    });
+
+    socket.on('playerCount', count => {
+        startBtn.disabled = count < 2;
+    });
+
+    socket.on('start', () => {
+        startBtn.disabled = true;
+        initializeGame();
     });
 
     /* ───────────────────────────── Game Loop ───────────────────────────── */

--- a/index.js
+++ b/index.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const http = require('http');
+const { Server } = require('socket.io');
+
+const app = express();
+const server = http.createServer(app);
+const io = new Server(server);
+
+app.use(express.static(__dirname));
+
+const broadcast = io.of('/broadcast');
+
+const players = new Map(); // id -> {socketId, color}
+const lines = [];
+let gameStarted = false;
+
+function emitPlayerCount() {
+    broadcast.emit('playerCount', players.size);
+}
+
+broadcast.on('connection', (socket) => {
+    socket.on('join', ({ id, color }) => {
+        players.set(id, { socketId: socket.id, color });
+        socket.emit('state', { players: Object.fromEntries(players), lines });
+        emitPlayerCount();
+    });
+
+    socket.on('segment', (seg) => {
+        lines.push(seg);
+        socket.broadcast.emit('segment', seg);
+    });
+
+    socket.on('dead', ({ id }) => {
+        players.delete(id);
+        socket.broadcast.emit('dead', { id });
+        emitPlayerCount();
+    });
+
+    socket.on('start', () => {
+        if (!gameStarted && players.size >= 2) {
+            gameStarted = true;
+            lines.length = 0;
+            broadcast.emit('start');
+        }
+    });
+
+    socket.on('disconnect', () => {
+        for (const [id, info] of players.entries()) {
+            if (info.socketId === socket.id) {
+                players.delete(id);
+                broadcast.emit('dead', { id });
+                emitPlayerCount();
+                break;
+            }
+        }
+    });
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => console.log(`Server running on port ${port}`));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,13 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "private": true
+  ,
+  "dependencies": {
+    "express": "^4.18.2",
+    "socket.io": "^4.7.2"
+  }
 }


### PR DESCRIPTION
## Summary
- add Express/Socket.IO server implementation
- wait for two players to enable the start button
- let one player start the game for all connected players
- expose `npm start` script with dependencies

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails to run due to missing module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6865512925b083339f8608d060a305ae