### PR TITLE
Fix duplicate player ID handling and add server logs

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,8 +92,17 @@
 
     /* ───────────────────────────── Socket Events ───────────────────────────── */
     socket.on('state', ({ players:all, lines })=>{
-        Object.assign(players, all);
-        lines.forEach(seg => drawDot(seg.x, seg.y, players[seg.id].color));
+        for (const [id, info] of Object.entries(all)){
+            if(!players[id]){
+                players[id] = { id, color: info.color, path: [], alive: true,
+                    x:0, y:0, angle:0, keys:{left:false,right:false} };
+            }else{
+                players[id].color = info.color;
+            }
+        }
+        lines.forEach(seg => {
+            if(players[seg.id]) drawDot(seg.x, seg.y, players[seg.id].color);
+        });
     });
 
     socket.on('segment', ({ id, x, y })=>{


### PR DESCRIPTION
## Summary
- ensure player connections are tracked by socket id on the server
- provide a helper to format the player list for new clients
- log join, dead and disconnect events
- keep existing client player data when receiving the initial state

## Testing
- `npm install`
- `npm start` *(fails: EADDRINUSE if port already in use)*


------
https://chatgpt.com/codex/tasks/task_e_68655b2648f88333a42c70d654a81586